### PR TITLE
[PGS] 약수의 개수와 덧셈, 예산, 크레인 인형뽑기 게임, 폰켓몬, 완주하지 못한 선수, 2016, 최소직사각형 / hotbeakb

### DIFF
--- a/programmers/hotbreakb/2016.py
+++ b/programmers/hotbreakb/2016.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+
+
+def solution(a, b):
+    YEAR = 2016
+    days = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
+    day = datetime.strptime(f"{YEAR}-{a}-{b}", "%Y-%m-%d").weekday()
+    return days[day]
+
+
+print(solution(5, 24))

--- a/programmers/hotbreakb/약수의-개수와-덧셈.py
+++ b/programmers/hotbreakb/약수의-개수와-덧셈.py
@@ -1,0 +1,26 @@
+def solution(left, right):
+    answer = 0
+    for num in range(left, right+1):
+        if getDivisorCount(num) % 2 == 0:
+            answer += num
+        else:
+            answer -= num
+    return answer
+
+
+def getDivisorCount(num: int) -> int:
+    count = 0
+    for i in range(1, int(num**(0.5))+1):
+        if num % i != 0:
+            continue
+        if i == num**(0.5):
+            count += 1
+        else:
+            count += 2
+
+    return count
+
+
+left = 9
+right = 9
+print(solution(left, right))

--- a/programmers/hotbreakb/예산.py
+++ b/programmers/hotbreakb/예산.py
@@ -1,0 +1,17 @@
+def solution(d, budget):
+    answer = 0
+    sum = 0
+
+    d = sorted(d)
+    for num in d:
+        sum += num
+
+        if sum > budget:
+            break
+        answer += 1
+    return answer
+
+
+d = [1, 2, 8, 9]
+budget = 2
+print(solution(d, budget))

--- a/programmers/hotbreakb/완주하지-못한-선수.py
+++ b/programmers/hotbreakb/완주하지-못한-선수.py
@@ -1,0 +1,13 @@
+from collections import Counter
+
+
+def solution(participant, completion):
+    completionCounter = Counter(completion)
+
+    for key, value in Counter(participant).items():
+        if key not in completionCounter.keys() or completionCounter[key] != value:
+            return key
+
+
+print(solution(["marina", "josipa", "nikola", "marina", "filipa"], [
+      "josipa", "filipa", "marina", "nikola"]))

--- a/programmers/hotbreakb/최소직사각형.py
+++ b/programmers/hotbreakb/최소직사각형.py
@@ -1,0 +1,14 @@
+def solution(sizes):
+    answer = 0
+    cards = []
+    width, height = 0, 0
+    for card in sizes:
+        card = sorted(card)
+        width = max(width, card[0])
+        height = max(height, card[1])
+
+    return width*height
+
+
+sizes = [[14, 4], [19, 6], [6, 16], [18, 7], [7, 11]]
+print(solution(sizes))

--- a/programmers/hotbreakb/크레인-인형뽑기-게임.py
+++ b/programmers/hotbreakb/크레인-인형뽑기-게임.py
@@ -1,0 +1,35 @@
+def solution(board, moves):
+    answer = 0
+    size = len(board)
+    boardDollHeight = checkBoardDollHeight(board, size)
+    stack = []
+
+    for m in moves:
+        if boardDollHeight[m-1] > size-1:
+            continue
+        doll = board[boardDollHeight[m-1]][m-1]
+        boardDollHeight[m-1] += 1
+        if stack and stack[-1] == doll:
+            answer += 2
+            stack.pop()
+            continue
+        stack.append(doll)
+
+    return answer
+
+
+def checkBoardDollHeight(board: list, size: int) -> list:
+    dollHeight = [size]*size
+    for w in range(size):
+        for h in range(size):
+            if board[h][w] != 0:
+                dollHeight[w] = h
+                break
+
+    return dollHeight
+
+
+board = [[1, 0, 0, 0, 0], [1, 0, 0, 0, 0], [
+    1, 0, 0, 0, 0], [1, 0, 0, 0, 0], [1, 0, 0, 0, 0]]
+moves = [1, 1, 1, 1, 1]
+print(solution(board, moves))

--- a/programmers/hotbreakb/폰켓몬.py
+++ b/programmers/hotbreakb/폰켓몬.py
@@ -1,0 +1,2 @@
+def solution(nums):
+    return min(len(set(nums)), len(nums)//2)


### PR DESCRIPTION
## 문제 풀이

### 1. 약수의 개수와 덧셈
- 약수의 개수에 따라 값을 계산한다.
- 약수의 개수가 홀수인 수는 제곱수를 포함하고 있기 때문에 제곱수인지만 확인하면 쉽게 풀 수 있다.

### 2. 예산
- 작은 것부터 더해서 예산을 초과하는지 확인한다.

### 3. 크레인 인형뽑기 게임
- `board`에서 인형이 있는 높이를 확인하고 `moves`에 따라 높이를 조절하며 `stack` 맨 위에 같은 인형이 있는지 확인한다.

### 4. 폰켓몬
- `set`으로 종류를 확인한다.

### 5. 완주하지 못한 선수
- 동명이인을 처리하는 부분에서 시간이 좀 걸렸다.
- `Counter`를 사용한 후에 차이를 확인한다.
- `for`문을 도는 것보다는 `-`연산자로 확인하는 게 더 빠르다.