### PR TITLE
[PGS] 약수의 개수와 덧셈, 예산, 완주하지 못한 선수, 크레인 인형뽑기 게임, 폰켓몬, 2016, 최소직사각형 / WhiteHyun

### DIFF
--- a/programmers/whitehyun/2016.py
+++ b/programmers/whitehyun/2016.py
@@ -1,0 +1,30 @@
+#
+#  2016
+#  https://programmers.co.kr/learn/courses/30/lessons/12901
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/09.
+#
+
+
+def solution(month, day):
+    total_days = day
+    weekends = ("THU", "FRI", "SAT", "SUN", "MON", "TUE", "WED")
+
+    month -= 1
+    while month:
+        # 1 3 5 7 8 10 12
+        if (month <= 7 and month & 1 == 1) or (month >= 8 and month & 1 == 0):
+            total_days += 31
+        # 2
+        elif month == 2:
+            total_days += 29
+        # 4 6 9 11
+        else:
+            total_days += 30
+        month -= 1
+
+    return weekends[total_days % 7]
+
+
+print(solution(5, 24))

--- a/programmers/whitehyun/약수의-개수와-덧셈.py
+++ b/programmers/whitehyun/약수의-개수와-덧셈.py
@@ -1,0 +1,38 @@
+#
+#  약수의 개수와 덧셈
+#  https://programmers.co.kr/learn/courses/30/lessons/77884
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/09.
+#
+
+
+from functools import reduce
+
+
+def solution(left, right):
+    answer = 0
+    for number in range(left, right + 1):
+        factorization = {}
+        modular = 2
+        temp_number = number
+        while temp_number != 1:
+            if temp_number % modular == 0:
+                if modular not in factorization:
+                    factorization[modular] = 1
+                factorization[modular] += 1
+                temp_number //= modular
+            else:
+                modular += 1
+
+        # 약수의 개수
+        if reduce(lambda acc, element: acc * element, factorization.values(), 1) & 1:
+            answer -= number
+        else:
+            answer += number
+    return answer
+
+
+if __name__ == "__main__":
+    for left, right in ((13, 17), (24, 27)):
+        print(solution(left, right))

--- a/programmers/whitehyun/예산.py
+++ b/programmers/whitehyun/예산.py
@@ -1,0 +1,25 @@
+#
+#  예산
+#  https://programmers.co.kr/learn/courses/30/lessons/12982
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/09.
+#
+
+
+def solution(d, budget):
+    answer = 0
+    departments = sorted(d)
+    for department in departments:
+        budget -= department
+        if budget >= 0:
+            answer += 1
+
+    return answer
+
+
+if __name__ == "__main__":
+    d = [[1, 3, 2, 5, 4], [2, 2, 3, 3]]
+    budget = [9, 10]
+    for dd, bb in zip(d, budget):
+        print(solution(dd, bb))

--- a/programmers/whitehyun/완주하지-못한-선수.py
+++ b/programmers/whitehyun/완주하지-못한-선수.py
@@ -1,0 +1,18 @@
+#
+#  완주하지 못한 선수
+#  https://programmers.co.kr/learn/courses/30/lessons/42576
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/09.
+#
+
+
+def solution(participant, completion):
+    participant.sort()
+    completion.sort()
+    for i in range(len(completion)):
+        if completion[i] == participant[i]:
+            continue
+        else:
+            return participant[i]
+    return participant[-1]

--- a/programmers/whitehyun/최소직사각형.py
+++ b/programmers/whitehyun/최소직사각형.py
@@ -1,0 +1,22 @@
+#
+#  최소직사각형
+#  https://programmers.co.kr/learn/courses/30/lessons/86491
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/09.
+#
+
+from functools import reduce
+
+
+def solution(sizes):
+    # 크기를 정렬
+    sorted_sizes = [size if size[0] < size[1] else [size[1], size[0]] for size in sizes]
+    return reduce(
+        lambda acc, x: acc * max(x),
+        zip(*sorted_sizes),
+        1,
+    )
+
+
+print(solution([[10, 7], [12, 3], [8, 15], [14, 7], [5, 15]]))

--- a/programmers/whitehyun/크레인-인형뽑기-게임.py
+++ b/programmers/whitehyun/크레인-인형뽑기-게임.py
@@ -1,0 +1,49 @@
+#
+#  크레인 인형뽑기 게임
+#  https://programmers.co.kr/learn/courses/30/lessons/64061
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/09.
+#
+
+
+def solution(board, moves):
+    count = len(board)
+    stack_brackets = []
+    answer = 0
+
+    for move in moves:
+        move -= 1
+        index = 0
+
+        # 인형을 집어듦
+        while board[index][move] == 0:
+            index += 1
+            if index == count:
+                break
+        else:
+            stack_brackets.append(board[index][move])
+            board[index][move] = 0
+
+        # 바구니 점검
+        if len(stack_brackets) > 1 and stack_brackets[-1] == stack_brackets[-2]:
+            stack_brackets.pop()
+            stack_brackets.pop()
+            answer += 2
+
+    return answer
+
+
+if __name__ == "__main__":
+    print(
+        solution(
+            [
+                [0, 0, 0, 0, 0],
+                [0, 0, 1, 0, 3],
+                [0, 2, 5, 0, 1],
+                [4, 2, 4, 4, 2],
+                [3, 5, 1, 3, 1],
+            ],
+            [1, 5, 3, 5, 1, 2, 1, 4],
+        )
+    )

--- a/programmers/whitehyun/폰켓몬.py
+++ b/programmers/whitehyun/폰켓몬.py
@@ -1,0 +1,15 @@
+#
+#  폰켓몬
+#  https://programmers.co.kr/learn/courses/30/lessons/1845
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/09.
+#
+
+
+def solution(nums):
+    count = len(nums)
+    kind_count = len(set(nums))
+    while count - kind_count < count >> 1:
+        kind_count -= 1
+    return kind_count


### PR DESCRIPTION
## 문제 풀이

### 1. 약수의 개수와 덧셈

- 약수의 개수는 소인수분해한 지수를 1씩 더하여 곱한 것과 같다는 것을 이용
  - `reduce`를 사용하여 구함

### 2. 예산

- 각 부서별 신청한 금액에 대해 정렬
- 예산을 줄여가며 부서 개수를 셈

### 3. 완주하지 못한 선수

- `participant`, `completion`리스트를 정렬한다.
- 각 원소마다 같은지 비교하고, 아닌경우 참여자 리스트의 해당 원소의 문자열을 리턴한다.
- 모두 다 같다면, 참여자의 마지막 원소를 리턴한다.

### 4. 크레인 인형뽑기 게임

- `moves`에 있는 값을 통해 board에 접근한 값을 `stack`에 append하고 board값을 0으로 처리한다.
- stack에서 인형이 같은 것이 두 개 있다면 `pop 연산`을 **두 번 실행**하고 정답값을 2 더한다.

### 5. 폰켓몬

- set으로 종을 구하고, 그 개수가 절반 이상인경우 1씩 빼나가면서 개수를 세어 리턴

### 6. 2016

- `month`를 `day`로 환산하여 7로 나눈 나머지로 일주일에 대한 문자열로부터 인덱스로 접근

### 7. 최소직사각형

- 모든 사이즈에 대해 정렬하고 각 원소별 큰 사이즈를 곱하여 리턴

<!-- ## 문제 회고 -->
<!-- Optional, 회고를 작성하고 싶다면 위 주석을 풀어주세요! -->
