### PR TITLE
[PGS] 두 정수 사이의 합, 가운데 글자 가져오기, 같은 숫자는 싫어, 124 나라의 숫자, 오픈채팅방 / WhiteHyun

### DIFF
--- a/programmers/whitehyun/124 나라의 숫자.py
+++ b/programmers/whitehyun/124 나라의 숫자.py
@@ -1,0 +1,32 @@
+#
+#  124 나라의 숫자
+#  https://programmers.co.kr/learn/courses/30/lessons/12899
+#  Version: Python 3.8.12
+#
+#  Created by WhiteHyun on 2022/04/10.
+#
+
+
+def solution(n):
+    number = "412"
+    answer = ""
+    while n > 3:
+        answer += number[n % 3]
+        if n % 3 == 0:
+            n //= 3
+            n -= 1
+        else:
+            n //= 3
+    answer += number[n % 3]
+    return answer[::-1]
+
+
+if __name__ == "__main__":
+    number = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    answer = [1, 2, 4, 11, 12, 14, 21, 22, 24, 41]
+    for n, a in zip(number, answer):
+        print(solution(n))
+        if solution(n) == a:
+            print("정답")
+        else:
+            print("실패")

--- a/programmers/whitehyun/가운데 글자 가져오기.py
+++ b/programmers/whitehyun/가운데 글자 가져오기.py
@@ -1,0 +1,14 @@
+#
+#  가운데 글자 가져오기
+#  https://programmers.co.kr/learn/courses/30/lessons/12903
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/10.
+#
+
+
+def solution(s):
+    count = len(s)
+    if count & 1:
+        return s[count >> 1]
+    return s[(count >> 1) - 1 : (count >> 1) + 1]

--- a/programmers/whitehyun/같은 숫자는 싫어.py
+++ b/programmers/whitehyun/같은 숫자는 싫어.py
@@ -1,0 +1,16 @@
+#
+#  같은 숫자는 싫어
+#  https://programmers.co.kr/learn/courses/30/lessons/12906
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/10.
+#
+
+
+def solution(arr):
+    answer = []
+    for element in arr:
+        if answer and answer[-1] == element:
+            continue
+        answer.append(element)
+    return answer

--- a/programmers/whitehyun/두 정수 사이의 합.py
+++ b/programmers/whitehyun/두 정수 사이의 합.py
@@ -1,0 +1,10 @@
+#
+#  두 정수 사이의 합
+#  https://programmers.co.kr/learn/courses/30/lessons/12912
+#  Version: Python 3.8.12
+#
+#  Created by WhiteHyun on 2022/04/10.
+#
+
+
+solution = lambda a, b: sum(range(a, b + 1)) if a < b else sum(range(b, a + 1))

--- a/programmers/whitehyun/오픈채팅방.py
+++ b/programmers/whitehyun/오픈채팅방.py
@@ -1,0 +1,38 @@
+#
+#  오픈채팅방
+#  https://programmers.co.kr/learn/courses/30/lessons/42888
+#  Version: Python 3.8.12
+#
+#  Created by WhiteHyun on 2022/04/11.
+#
+
+
+def solution(records: list) -> list:
+    user_id = {}
+    result = []
+    for record in records:
+        command, *args = record.split()
+        if command == "Leave":
+            result.append((args[0], "님이 나갔습니다."))
+            continue
+        uid, nick_name = args
+        user_id[uid] = nick_name
+        if command == "Enter":
+            result.append((uid, "님이 들어왔습니다."))
+
+    answer = list(map(lambda x: user_id[x[0]] + x[1], result))
+
+    return answer
+
+
+print(
+    solution(
+        [
+            "Enter uid1234 Muzi",
+            "Enter uid4567 Prodo",
+            "Leave uid1234",
+            "Enter uid1234 Prodo",
+            "Change uid4567 Ryan",
+        ]
+    )
+)


### PR DESCRIPTION
## 문제 풀이

### 1. 두 정수 사이의 합

- `range()`와 `sum()`을 사용

### 2. 가운데 글자 가져오기

- 문자열의 홀짝여부에 따라 처리를 다르게 함

### 3. 같은 숫자는 싫어

- 리스트를 하나 두고, 배열을 처음부터 끝까지 돌면서 리스트의 끝 값과 같으면 넘어가고 다르면 값을 넣는다.

### 4. 124 나라의 숫자

숫자를 [1, 2, 4]만 사용하기 때문에 일반적인 진법변환과는 차이가 있다.
> `3진법`은 0, 1, 2를 사용하지만 124나라는 `0`이 없다.

그래서 직접 그려가며 비교해본 결과, 아래와 같은 규칙을 찾을 수 있었다.

> 40: aaaa        
> 13: aaa
> 4: aa
> 1: a

> 17: abb
>  5: ab
>  1: a

<img width="118" alt="image" src="https://user-images.githubusercontent.com/57972338/162602931-a8e8ee04-a073-4311-9daa-1fb766b81271.png">

---

40을 3으로 나눈 나머지 -> 1      --> a
40을 3으로 나눈 몫       -> 13

13을 3으로 나눈 나머지 -> 1       --> a
13을 3으로 나눈 몫       -> 4


4을 3으로 나눈 나머지 -> 1       --> a
4을 3으로 나눈 몫       -> 1

1 --> a

위와 같이 3을 나눈 나머지를 인덱스로 두고 `["c", "a", "b"]`나 `"cab"`와 같은 참조용 변수를 선언하여 해당 진법을 구할 수 있다.
그 이후 나눈 몫으로 다시 반복하여 진행하면 된다.

조심해야할 건, 나누어 떨어지는 수에 대해서는 이상하게 적용됨을 알 수 있다.

<img width="157" alt="image" src="https://user-images.githubusercontent.com/57972338/162603241-3aa6a7cb-4f9f-4fb6-9218-0c0bd7101fae.png">

나누어 떨어지지 않는 수는 3으로 나눈 몫이 자신의 끝 수를 제외한 수와 같았으나,
나누어 떨어지는 수는 3으로 나눈 몫에서 -1한 값이 자신의 끝 수를 제외한 수와 같다.

즉, 몫에서 1을 뺀 값이 **중복된 값**이기 때문에, `나눈 몫에서 1을 빼어` 진행하면 된다.

### 5. 오픈채팅방

- 닉네임이 계속 변동되기 떄문에 `{user_id: nick_name}`인 dictionary를 가져옴

<!-- ## 문제 회고 -->
<!-- Optional, 회고를 작성하고 싶다면 위 주석을 풀어주세요! -->
