### PR TITLE
[PGS] 방문 길이, 점프와 순간 이동, 위장, 예상 대진표, 튜플 / WhiteHyun

### DIFF
--- a/programmers/whitehyun/방문 길이.py
+++ b/programmers/whitehyun/방문 길이.py
@@ -1,0 +1,32 @@
+#
+#  방문 길이
+#  https://programmers.co.kr/learn/courses/30/lessons/49994
+#  Version: Python 3.8.12
+#
+#  Created by WhiteHyun on 2022/04/19.
+#
+
+
+def solution(dirs):
+    dir_dict = {"U": (-1, 0), "D": (1, 0), "L": (0, -1), "R": (0, 1)}
+    visited = set()
+    count = 0
+    x, y = 5, 5  # 초기 위치
+    for dir in dirs:
+        # dx, dy: 움직인 위치
+        dx, dy = dir_dict[dir]
+        dx += x
+        dy += y
+        # 위치를 벗어나면 다시 진행
+        if dx < 0 or dx > 10 or dy < 0 or dy > 10:
+            continue
+
+        # 방문하지 않았다면
+        if (x, y, dx, dy) not in visited:
+            count += 1
+            visited.add((x, y, dx, dy))
+            visited.add((dx, dy, x, y))
+        # 이미 방문한 곳인 경우 위치만 갱신하고 반복문 진행
+        x, y = dx, dy
+
+    return count

--- a/programmers/whitehyun/영어 끝말잇기.py
+++ b/programmers/whitehyun/영어 끝말잇기.py
@@ -1,0 +1,20 @@
+#
+#  영어 끝말잇기
+#  https://programmers.co.kr/learn/courses/30/lessons/12981
+#  Version: Python 3.8.12
+#
+#  Created by WhiteHyun on 2022/04/19.
+#
+
+
+def solution(n, words):
+    answer = [0, 0]
+
+    speak_set = {words[0]}
+    for i in range(1, len(words)):
+        if words[i] in speak_set or words[i - 1][-1] != words[i][0]:
+            answer[0] = i % n + 1
+            answer[1] = i // n + 1
+            break
+        speak_set.add(words[i])
+    return answer

--- a/programmers/whitehyun/예상 대진표.py
+++ b/programmers/whitehyun/예상 대진표.py
@@ -1,0 +1,29 @@
+#
+#  예상 대진표
+#  https://programmers.co.kr/learn/courses/30/lessons/12985
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/19.
+#
+
+
+import math
+
+
+def solution(n, a, b):
+
+    while (a <= (n >> 1) and b <= (n >> 1)) or (a > (n >> 1) and b > (n >> 1)):
+        n >>= 1
+        if a > (n >> 1):
+            a = (a - 1) % n + 1
+            b = (b - 1) % n + 1
+    return int(math.log2(n))
+
+
+if __name__ == "__main__":
+    print(solution(8, 4, 7))
+    print(solution(8, 7, 8))
+    print(solution(8, 3, 4))
+    print(solution(16, 9, 12))
+    print(solution(16, 14, 16))
+    print(solution(16, 15, 16))

--- a/programmers/whitehyun/위장.py
+++ b/programmers/whitehyun/위장.py
@@ -1,0 +1,18 @@
+#
+#  위장
+#  https://programmers.co.kr/learn/courses/30/lessons/42578
+#  Version: Python 3.8.12
+#
+#  Created by WhiteHyun on 2022/04/19.
+#
+
+
+def solution(clothes):
+    answer = 1
+    clothes_dict = {}
+    for _, type in clothes:
+        clothes_dict[type] = clothes_dict.get(type, 1) + 1
+
+    for _, count in clothes_dict.items():
+        answer *= count
+    return answer - 1

--- a/programmers/whitehyun/점프와 순간 이동.py
+++ b/programmers/whitehyun/점프와 순간 이동.py
@@ -1,0 +1,11 @@
+#
+#  점프와 순간 이동
+#  https://programmers.co.kr/learn/courses/30/lessons/12980
+#  Version: Python 3.8.12
+#
+#  Created by WhiteHyun on 2022/04/19.
+#
+
+
+def solution(n):
+    return bin(n).count("1")

--- a/programmers/whitehyun/튜플.py
+++ b/programmers/whitehyun/튜플.py
@@ -1,0 +1,36 @@
+#
+#  튜플
+#  https://programmers.co.kr/learn/courses/30/lessons/64065
+#  Version: Python 3.9.10
+#
+#  Created by WhiteHyun on 2022/04/19.
+#
+
+
+def solution(s):
+    answer = []
+    # == 집합 값 추출 ==
+    value_list = s[2:-2].split("},{")
+    value_list = sorted(value_list, key=len)
+
+    for sequence in value_list:
+        # == 집합 내 원소 값 추출 ==
+        for element in map(int, sequence.split(",")):
+            if element not in answer:
+                answer.append(element)
+    return answer
+
+
+if __name__ == "__main__":
+    inputs = [
+        "{{2},{2,1},{2,1,3},{2,1,3,4}}",
+        "{{1,2,3},{2,1},{1,2,4,3},{2}}",
+        "{{20,111},{111}}",
+        "{{123}}",
+        "{{4,2,3},{3},{2,3,4,1},{2,3}}",
+    ]
+    y = [[2, 1, 3, 4], [2, 1, 3, 4], [111, 20], [123], [3, 2, 4, 1]]
+
+    for predict, answer in zip(map(lambda value: solution(value), inputs), y):
+        print(predict)
+        assert predict == answer


### PR DESCRIPTION
## 문제 풀이

### 1. 방문 길이

좌표에서 방향처리를 요하는 문제이기 때문에, 각 방향별 방문표시를 처리해두어야 한다.
`set collection`을 사용하여 튜플 `(before_x, before_y, next_x, next_y)`와 `(next_x, next_y, before_x, before_y)`를 저장해두었다.

### 2. 점프와 순간 이동

2진수로 변환한 뒤 1을 카운트해주면 된다.

### 3. 위장

각 부위별 옷 가지수 + 1한 뒤, 원소별 곱셈 이후 -1한 값을 리턴한다.
`+1` 한 이유는, 옷가지를 선택하지 않았을 경우(`None`)도 존재하기 때문이고,
`-1` 한 이유는 모든 옷가지를 입지 않았을 경우는 제외해야하므로 뺐다.

### 4. 영어 끝말잇기

반복문을 돌며 이전 단어의 끝자리가 같은지 또는 기존에 불렸던 단어가 있는지를 확인한다.
만약 위 기준에 해당된다면, 인덱스를 인원수로 나눈 몫에서 `+1`한 값이 `시행 수`가 되며 나머지를 `+1`한 값은 `걸린 사람`이 된다.

### 5. 예상 대진표

log(n) 시간복잡도를 가진다.
A플레이어와 B플레이어가 n x 2<sup>-1</sup>을 기준으로 양옆에 존재한다면 log<sub>2</sub>n이 서로 만날 수 있는 라운드 수가 된다.
따라서 while문으로 두 플레이어가 n을 기점으로 양옆이 될 때까지 반복하였으며, 아닐 경우 a와 b의 값을 n이 절반으로 줄어든 값과 맞춰 설정하였다.
ex) n = 8이고, a, b = 7, 8일 때, while 문에서 n이 4로 줄어들었다면, a, b = 3, 4로 바꾸어 진행



### 6. 튜플

1. 원소의 값을 추출하기 위해 다음의 식을 적용하였다.
```python
value_list = s[2:-2].split("},{")
```
  - 이를 진행하면 "{{2},{2,1},{2,1,3},{2,1,3,4}}" → ['2', '2,1', '2,1,3', '2,1,3,4']로 변환된다.

2. 변환된 리스트를 길이에 따라 정렬해준다.
3. 리스트의 원소를 다시 쉼표(`,`)로 나누어 리스트를 생성한 뒤 정답 리스트에 원소를 삽입한다.
  - 만약 존재하는 숫자라면 넘어간다.
