### PR TITLE
[PGS] 쿼드압축 후 개수 세기, 큰 수 만들기 / WhiteHyun

### DIFF
--- a/programmers/whitehyun/쿼드압축 후 개수 세기.py
+++ b/programmers/whitehyun/쿼드압축 후 개수 세기.py
@@ -1,0 +1,59 @@
+#
+#  쿼드압축 후 개수 세기
+#  https://school.programmers.co.kr/learn/courses/30/lessons/68936
+#  Version: Python 3.10.6
+#
+#  Created by whitehyun on 2022/11/03.
+#
+
+
+def recursion(matrix: list, value: list) -> list:
+
+    if all(map(lambda x: x.count(0) == len(matrix), matrix)):
+        value[0] += 1
+        return value
+
+    if all(map(lambda x: x.count(1) == len(matrix), matrix)):
+        value[1] += 1
+        return value
+
+    half = len(matrix) >> 1
+
+    quadrant1 = recursion([*map(lambda x: x[:half], matrix[:half])], value)  # 1사분면
+    quadrant2 = recursion([*map(lambda x: x[:half], matrix[half:])], value)  # 2사분면
+    quadrant3 = recursion([*map(lambda x: x[half:], matrix[:half])], value)  # 3사분면
+    quadrant4 = recursion([*map(lambda x: x[half:], matrix[half:])], value)  # 4사분면
+
+    return value
+
+
+def solution(arr: list) -> list:
+    answer = [0, 0]
+
+    answer = recursion(arr, answer)
+    return answer
+
+
+if __name__ == "__main__":
+    matrices = [
+        [[1, 1, 0, 0], [1, 0, 0, 0], [1, 0, 0, 1], [1, 1, 1, 1]],
+        [
+            [1, 1, 1, 1, 1, 1, 1, 1],
+            [0, 1, 1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 1, 1, 1, 1],
+            [0, 1, 0, 0, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 1, 1],
+            [0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 1, 0, 0, 1],
+            [0, 0, 0, 0, 1, 1, 1, 1],
+        ],
+    ]
+    answers = [[4, 9], [10, 15]]
+
+    for matrix, answer in zip(matrices, answers):
+        predicted_value = solution(matrix)
+        assert (
+            predicted_value == answer
+        ), f"{predicted_value} is not correct, answer is {answer}"
+
+    print("Succeed")

--- a/programmers/whitehyun/큰 수 만들기.py
+++ b/programmers/whitehyun/큰 수 만들기.py
@@ -1,0 +1,46 @@
+#
+#  큰 수 만들기
+#  https://school.programmers.co.kr/learn/courses/30/lessons/42883
+#  Version: Python 3.10.6
+#
+#  Created by whitehyun on 2022/11/03.
+#
+
+
+def solution(number: str, k: int) -> str:
+    number_list = [*map(int, [*number[::-1]])]  # [1, 2, 3, 4] 처럼 만듦
+    stack = [number_list.pop()]
+    while number_list:
+        element = number_list.pop()
+        while k > 0 and stack and stack[-1] < element:
+            stack.pop()
+            k -= 1
+
+        stack.append(element)
+
+    while k > 0:
+        stack.pop()
+        k -= 1
+
+    return "".join(map(str, stack))
+
+
+if __name__ == "__main__":
+    numbers = [
+        "1924",
+        "1231234",
+        "4177252841",
+        "1942",
+        "1942",
+        "517368",
+    ]
+    ks = [2, 3, 4, 2, 3, 4]
+    answers = ["94", "3234", "775841", "94", "9", "78"]
+
+    for number, k, answer in zip(numbers, ks, answers):
+        predicted_value = solution(number, k)
+        assert (
+            predicted_value == answer
+        ), f"{predicted_value} is not correct, answer is {answer}"
+
+    print("Succeed")


### PR DESCRIPTION
## 문제 풀이

### 1. 쿼드압축 후 개수 세기

무조건 너비와 높이는 2의 배수이기 때문에 절반으로 나눈 후 `1~4사분면`의 리스트를 만들어 `recursive function`으로 처리

https://github.com/Egg-Ring/Cooking/commit/51ae9a89a7a687da0e4e362d7ba83867a9793d3e#diff-cae553b37c2cb36d6d4a863f31725db6f90ab38b74b11afe4fbc730ea1ff2951R22-R25
위 코드를 보면 재귀로 돌린 값으로 value값 갱신시키려고  `quadrant1~4`로 저장해두었는데 막상 생각해보니 list가 값복사가 아닌 참조복사여서 자동으로 갱신되어서 저장할 필요가 없어졌음. 하지만 따로 지우진 않았음(이유 없음, 방금 발견함 ㅎ).

### 2. 큰 수 만들기

큰 수를 만들려면 결국엔 첫째 자리 수부터 차례대로 크게 설정하면 되는 것임.
ex: `1234`에서 `k`가 `2`이면 첫 째 자리 수가 `1, 2` 가 아닌 `3`이 오는 게 제일 크므로 `1, 2`를 삭제함
ex: `89542`에서 `k`가 `3`이면, 첫 째 자리 수가 `9`가 오는 게 제일 크기 때문에 앞의 `8`을 제거, 그리고 두 번 째 자리는 `5, 4, 2` 중에서 `5`가 제일 크기 때문에 `4, 2`는 제거

위 로직을 스택을 이용하여 처리

입력받아온 문자열을 거꾸로 하여 정수형 리스트로 재생성 (ex: "15984" -> [4, 8, 9, 5, 1])
-> 이유는 리스트의 `pop()`연산을 이용할 것이기 때문!

스택 변수를 하나 더 생성해두고, 재생성한 정수형 리스트를 pop하여 스택에 저장
만약 스택의 `peak`값보다 `pop()`하여 들어온 `element`가 더 크다면 스택의 `peak`값이 `element`보다 같거나 커질 때 까지 `pop()` 진행
example)
```
// Start
stack: []
list: [4, 8, 9, 5, 1]
k: 2

// == cycle 1 ==
stack: []
list: [4, 8, 9, 5] --> pop: 1
k: 2

stack: [] <-- 1
list [4, 8, 9, 5]
k: 2

stack: [1]
list [4, 8, 9, 5]
k: 2


// == cycle 2 ==
stack: [1]
list: [4, 8, 9] --> pop: 5
k: 2

stack: [1] <-- 5
list: [4, 8, 9]
k: 2

        1 pop
        ^
        |
stack: [ ] <-- 5
list: [4, 8, 9]
k: 1

stack: [5]
list: [4, 8, 9]
k: 1

// ....
```
이를 반복하고나면 k를 전부 쓰지 않고 모두 pop될 수 있는 경우도 생기기 때문에, stack의 `element`를 남은`k`만큼 제거한다.

ex) 입력값=`"48761"`, k=`3`일때 위 로직을 이용하였을 때 결과값이 k=`2`, stack=`[8, 7, 6, 1]`이 된다. 여기서 k 수만큼 pop 하면, `[8, 7]`이 되어 "87"이 제일 큰 수가 된다.